### PR TITLE
Set Node Attributes with Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Resource Model Source plugin that provides OCI Instances as nodes for Rundeck
 * Hostname will be the private IP address from the primary VNIC
     * Unless an `Override VNIC Tag` is specified
 * Username will be the same for all nodes
+* The OCI Tag namespace `rundeck` is used for setting node attributes (configurable)
 
 # Setup
 * Download a release zip file from GitHub and place in `$RD_BASE/libext`
@@ -30,3 +31,17 @@ If Rundeck is running on an OCI Instance, then you can setup Instance Principal 
 * Add a Policy to allow the Dynamic Group read access to instances
     * Identity > Policies
     * Example" `allow dynamic-group rundeck to read instance-family in tenancy`
+    
+
+# Node Classification
+
+The plugin will use any freeform tags or structured tags and add them as tags for the node. If you want to add attributes to the node, like `osFamily`, you can add a new OCI Tag namespace. 
+
+By default, the plugin will look for the `rundeck` OCI Tag namespace. Any tags defined for an instance will be added as an attribute to the node instead of added to the nodes tags. For example, the tag `rundeck.osfamily: windows` will be added to the node like this:
+
+```yaml
+- node1
+  osfamily: windows
+  tags: ...
+```
+

--- a/rundeck-oci-nodes-plugin/contents/nodes.py
+++ b/rundeck-oci-nodes-plugin/contents/nodes.py
@@ -21,6 +21,7 @@ node_user = environ.get('RD_CONFIG_NODE_USER', 'opc')
 vnic_tag = environ.get('RD_CONFIG_VNIC_TAG', None)
 defined_list = environ.get('RD_CONFIG_DEFINED_TAGS', None)
 freeform_enabled = environ.get('RD_CONFIG_FREEFORM_TAGS', None)
+attribute_namespace = environ.get('RD_CONFIG_ATTRIBUBTE_NAMESPACE', 'rundeck')
 
 # oci config
 
@@ -75,13 +76,18 @@ for instance in instances:
 
     if defined_list:
         for namespace in defined_list.split(','):
-            namespace_tags = instance.defined_tags.get(namespace)
-            if namespace_tags:
+            if namespace == attribute_namespace:
+                rd_tags = instance.defined_tags.get(namespace)
+                if (rd_tags is not None):
+                    node.update(rd_tags)
+            else:
+                namespace_tags = instance.defined_tags.get(namespace)
+                if namespace_tags:
                 # convert all defined tag values to comma seperated string
-                if node["tags"]:
-                    node["tags"] = node["tags"] + ", " + ', '.join(filter(None, namespace_tags.values()))
-                else:
-                    node["tags"] = ', '.join(filter(None, namespace_tags.values()))
+                    if 'tags' in node:
+                        node["tags"] = node["tags"] + ", " + ', '.join(filter(None, namespace_tags.values()))
+                    else:
+                        node["tags"] = ', '.join(filter(None, namespace_tags.values()))
 
     nodes[instance.display_name] = node
 

--- a/rundeck-oci-nodes-plugin/plugin.yaml
+++ b/rundeck-oci-nodes-plugin/plugin.yaml
@@ -13,6 +13,10 @@ providers:
       resource-format: resourcejson
       config:
         - type: String
+          name: compartment_desc
+          title: Compartment Description
+          description: Description of Compartment
+        - type: String
           name: compartment
           title: Compartment ID
           description: Enter the Compartment ID that contains the Nodes.
@@ -34,6 +38,11 @@ providers:
           name: defined_tags
           title: OCI Defined Tag Namespaces
           description: Enter a comma seperated list of OCI Defined Tag Namespaces to be included in Tag Value mapping to Rundeck Nodes. (optional)
+        - type: String
+          name: attribute_namespace
+          title: Attributes Tag Namespace
+          description: OCI Tag Namespace to add attributes to nodes. Default is `rundeck`
+          default: rundeck
         - type: Boolean
           name: freeform_tags
           title: OCI Freeform Tag Values


### PR DESCRIPTION
* Use an OCI Tag Namespace to set node attributes instead of adding to the node tags. For example, the tag `rundeck.osFamily: windows` will create this node attribute:

    ```yaml
    - node
      osFamily: windows
    ```

* Add a Description field for the plugin so you can label each plugin instance when used with multiple compartments.