### PR TITLE
Add OCI region support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 psadmin.io
+Copyright (c) 2022 psadmin.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/rundeck-oci-nodes-plugin/contents/nodes.py
+++ b/rundeck-oci-nodes-plugin/contents/nodes.py
@@ -40,7 +40,7 @@ else:
     # set the region in the config and signer
     
     signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
-    signer.region = region
+    # signer.region = region
     config = {'region': region}
     compute = oci.core.ComputeClient(config, signer=signer)
     network = oci.core.VirtualNetworkClient(config, signer=signer)

--- a/rundeck-oci-nodes-plugin/contents/nodes.py
+++ b/rundeck-oci-nodes-plugin/contents/nodes.py
@@ -22,6 +22,7 @@ vnic_tag = environ.get('RD_CONFIG_VNIC_TAG', None)
 defined_list = environ.get('RD_CONFIG_DEFINED_TAGS', None)
 freeform_enabled = environ.get('RD_CONFIG_FREEFORM_TAGS', None)
 attribute_namespace = environ.get('RD_CONFIG_ATTRIBUBTE_NAMESPACE', 'rundeck')
+region = environ.get('RD_CONFIG_ATTRIBUBTE_REGION', 'us-ashburn-1')
 
 # oci config
 
@@ -36,9 +37,13 @@ if config_file:
     network = oci.core.VirtualNetworkClient(config)
 ## assume InstancePrincipal, if oci config not provided
 else:
+    # set the region in the config and signer
+    
     signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
-    compute = oci.core.ComputeClient({}, signer=signer)
-    network = oci.core.VirtualNetworkClient({},signer=signer)
+    signer.region = region
+    config = {'region': region}
+    compute = oci.core.ComputeClient(config, signer=signer)
+    network = oci.core.VirtualNetworkClient(config, signer=signer)
 
 # process nodes
 instances = compute.list_instances(compartment_id).data

--- a/rundeck-oci-nodes-plugin/contents/nodes.py
+++ b/rundeck-oci-nodes-plugin/contents/nodes.py
@@ -22,7 +22,7 @@ vnic_tag = environ.get('RD_CONFIG_VNIC_TAG', None)
 defined_list = environ.get('RD_CONFIG_DEFINED_TAGS', None)
 freeform_enabled = environ.get('RD_CONFIG_FREEFORM_TAGS', None)
 attribute_namespace = environ.get('RD_CONFIG_ATTRIBUBTE_NAMESPACE', 'rundeck')
-region = environ.get('RD_CONFIG_ATTRIBUBTE_REGION', 'us-ashburn-1')
+region = environ.get('RD_CONFIG_REGION', 'us-ashburn-1')
 
 # oci config
 

--- a/rundeck-oci-nodes-plugin/plugin.yaml
+++ b/rundeck-oci-nodes-plugin/plugin.yaml
@@ -22,6 +22,11 @@ providers:
           description: Enter the Compartment ID that contains the Nodes.
           required: true
         - type: String
+          name: region
+          title: Region
+          description: Enter the Region that contains the Nodes (default us-ashburn-1).
+          required: true
+        - type: String
           name: node_user
           title: Default OCI Node User
           description: Enter the default user to use when connecting to OCI Nodes


### PR DESCRIPTION
* New config option to set the OCI region. Defaults to `us-ashburn-1` if not set in Rundeck.